### PR TITLE
Changes for v0.1.1

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,8 +2,13 @@ Revision history for Struct-Flatten-Template
 
 v0.1.1
 
+  [Incompatabilities]
+  - ignore_missing is now a read-only attribute.
+
   [Documentation]
   - Added more modules to the SEE ALSO section.
+
+  - Corrected POD: ignore_missing is true by default.
 
   [Other Changes]
   - Minor code tweaks.

--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Struct-Flatten-Template
 
+v0.1.1
+
+  [Documentation]
+  - Added more modules to the SEE ALSO section.
+
 v0.1.0  2014-08-01
 
-  - Initial version
+  - Initial version released.

--- a/Changes
+++ b/Changes
@@ -3,7 +3,12 @@ Revision history for Struct-Flatten-Template
 v0.1.1
 
   [Incompatabilities]
-  - ignore_missing is now a read-only attribute.
+  - Ignore_missing is now a read-only attribute.
+
+  [New Features]
+  - Added _path key that tracks the path in the data structure.
+
+  - The _index key is now deprecated.
 
   [Documentation]
   - Added more modules to the SEE ALSO section.

--- a/Changes
+++ b/Changes
@@ -13,6 +13,9 @@ v0.1.1
   [Other Changes]
   - Minor code tweaks.
 
+  - Explicit prerequsite for Test::Differences that caused failures
+    for some CPAN Testers.
+
 v0.1.0  2014-08-01
 
   - Initial version released.

--- a/Changes
+++ b/Changes
@@ -5,6 +5,9 @@ v0.1.1
   [Documentation]
   - Added more modules to the SEE ALSO section.
 
+  [Other Changes]
+  - Minor code tweaks.
+
 v0.1.0  2014-08-01
 
   - Initial version released.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,7 +23,10 @@ resources(
 
 configure_requires();
 
-build_requires( 'Test::Most' => 0, );
+build_requires(
+    'Test::Most'	=> 0,
+    'Test::Differences' => 0,
+);
 
 requires(
     'Moose'                => 0,
@@ -32,7 +35,10 @@ requires(
     'version'              => 0.77,
 );
 
-test_requires( 'Test::Most' => 0, );
+test_requires(
+    'Test::Most'	=> 0,
+    'Test::Differences' => 0,
+);
 
 install_as_cpan;
 auto_install;

--- a/lib/Struct/Flatten/Template.pm
+++ b/lib/Struct/Flatten/Template.pm
@@ -325,6 +325,8 @@ sub process_ARRAY {
 
 use namespace::autoclean;
 
+__PACKAGE__->meta->make_immutable;
+
 1;
 
 =head1 SEE ALSO

--- a/lib/Struct/Flatten/Template.pm
+++ b/lib/Struct/Flatten/Template.pm
@@ -4,7 +4,7 @@ use 5.008;
 
 use Moose;
 
-use version 0.77; our $VERSION = version->declare('v0.1.0');
+use version 0.77; our $VERSION = version->declare('v0.1.1');
 
 =head1 NAME
 
@@ -325,7 +325,15 @@ use namespace::autoclean;
 
 =head1 SEE ALSO
 
-L<Hash::Flatten>
+The following alternative modules can be used to flatten hashes:
+
+=over
+
+=item L<Data::Hash::Flatten>
+
+=item L<Hash::Flatten>
+
+=back
 
 =head1 AUTHOR
 

--- a/lib/Struct/Flatten/Template.pm
+++ b/lib/Struct/Flatten/Template.pm
@@ -149,12 +149,12 @@ If true, missing substructures will be ignored and the template will
 be processed.  This is useful for setting default values for missing
 parts of the structure.
 
-This is false by default.
+This is true by default.
 
 =cut
 
 has 'ignore_missing' => (
-    is      => 'rw',
+    is      => 'ro',
     isa     => 'Bool',
     default => 1,
 );

--- a/lib/Struct/Flatten/Template.pm
+++ b/lib/Struct/Flatten/Template.pm
@@ -134,9 +134,13 @@ It is intended to be used from within the L</handler>.
 has 'is_testing' => (
     is       => 'ro',
     isa      => 'Bool',
+    traits   => [qw/ Bool /],
     default  => 0,
     init_arg => undef,
-    writer   => '_set_is_testing',
+    handles  => {
+        '_set_is_testing' => 'set',
+        '_set_is_live'    => 'unset',
+    },
 );
 
 =head2 C<ignore_missing>
@@ -213,7 +217,7 @@ Process C<$struct> using the L</template>.
 
 sub run {
     my ( $self, $struct ) = @_;
-    $self->_set_is_testing(0);
+    $self->_set_is_live;
     $self->process($struct);
 }
 
@@ -228,7 +232,7 @@ itself.
 
 sub test {
     my ( $self, $struct ) = @_;
-    $self->_set_is_testing(1);
+    $self->_set_is_testing;
     $self->process( $self->template );
 }
 

--- a/lib/Struct/Flatten/Template.pm
+++ b/lib/Struct/Flatten/Template.pm
@@ -275,7 +275,7 @@ sub process {
     my $struct   = $args[0];
     my $template = $#args ? $args[1] : $self->template;
     my $index    = $args[2];
-    my @path     = @{ $args[3] // [ ] };
+    my @path     = @{ $args[3] || [ ] };
 
     if ( my $type = ref($template) ) {
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -3,8 +3,8 @@ use Test::Most;
 use_ok('Struct::Flatten::Template');
 
 my $tmpl = {
-    foo => { bar => \{ column => 0, title => 'X' } },
-    baz => [ \{ column => 1, indexed => 1, title => 'Y' }, ],
+    foo => { bar => \{ column => 0, title => 'X', path_is => [qw/ foo HASH ? HASH /] } },
+    baz => [ \{ column => 1, indexed => 1, title => 'Y', path_is => [qw/ baz HASH ? ARRAY /]  }, ],
 };
 
 my $struct = {
@@ -19,6 +19,8 @@ my @row;
 sub handler {
     my ( $obj, $val, $args ) = @_;
 
+    note( explain [ $val, $args ] );
+
     my $col = $args->{column};
 
     if ( $obj->is_testing ) {
@@ -30,6 +32,16 @@ sub handler {
         $col += $args->{_index} if $args->{indexed};
         $row[$col] = $val;
     }
+
+    if ($args->{path_is}) {
+
+      my @expected = @{$args->{path_is}};
+      $expected[-2] = $args->{_index};
+
+      is_deeply($args->{_path}, \@expected, '_path');
+
+    }
+
 }
 
 isa_ok my $p = Struct::Flatten::Template->new(


### PR DESCRIPTION
- Ignore_missing is now a read-only attribute.
- Added _path key that tracks the path in the data structure.
- The _index key is now deprecated.
- Added more modules to the SEE ALSO section.
- Corrected POD: ignore_missing is true by default.
- Minor code tweaks.
- Explicit prerequsite for Test::Differences that caused failures
  for some CPAN Testers.
